### PR TITLE
Update node version in Dockerfile to v18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:13-alpine
+FROM node:18-alpine
 
 WORKDIR /app
 


### PR DESCRIPTION
Se usaba en el Dockerfile una versión antigua de Nodejs, la 13-alpine. Esto hacía que no se pudiera realizar la siguiente importanción que se utiliza en el código.
```
const querystring = require("node:querystring");
```
No se había configurado correctamente el Dockerfile ya que no se había tenido en cuenta la versión de Nodejs utilizada en el entorno de desarrollo local.

Se cambia a la versión **18-alpine**.